### PR TITLE
Update for .NET Core 1.0.1

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "projects": [ "src", "test" ],
   "sdk": {
-    "version": "1.0.0-preview2-003121"
+    "version": "1.0.0-preview2-003131"
   }
 }

--- a/src/VisualRecognition/project.json
+++ b/src/VisualRecognition/project.json
@@ -14,8 +14,8 @@
   },
   "dependencies": {
     "Microsoft.AspNetCore.Diagnostics": "1.0.0",
-    "Microsoft.AspNetCore.Mvc": "1.0.0",
-    "Microsoft.AspNetCore.Server.Kestrel": "1.0.0",
+    "Microsoft.AspNetCore.Mvc": "1.0.1",
+    "Microsoft.AspNetCore.Server.Kestrel": "1.0.1",
     "Microsoft.AspNetCore.StaticFiles": "1.0.0",
     "Microsoft.Extensions.Configuration": "1.0.0",
     "Microsoft.Extensions.Configuration.CommandLine": "1.0.0",
@@ -24,18 +24,18 @@
     "Microsoft.Extensions.Configuration.Abstractions": "1.0.0",
     "Microsoft.Extensions.Configuration.FileExtensions": "1.0.0",
     "System.IO.Compression.ZipFile": "4.0.1",
-    "WatsonServices": "1.0.0"
+    "WatsonServices": "1.0.1"
   },
   "frameworks": {
     "netcoreapp1.0": {
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.0.0"
+          "version": "1.0.1"
         }
       },
       "imports": [
-        "dnxcore50",
+        "netcoreapp1.0",
         "netcore45",
         "portable-net45+netcore45+wp8+wp81+wpa81"
       ]
@@ -54,5 +54,5 @@
       "obj"
     ]
   },
-  "version": "1.0.0"
+  "version": "1.0.1"
 }

--- a/src/WatsonServices/project.json
+++ b/src/WatsonServices/project.json
@@ -4,12 +4,12 @@
   },
   "dependencies": {
     "Microsoft.AspNet.WebApi.Client": "5.2.3",
-    "Microsoft.AspNetCore.Mvc": "1.0.0",
     "Microsoft.Extensions.Configuration": "1.0.0",
     "Microsoft.Extensions.Configuration.Json": "1.0.0",
+    "Microsoft.Extensions.DependencyInjection": "1.0.0",
     "Microsoft.Extensions.Logging.Console": "1.0.0",
-    "Newtonsoft.Json": "9.0.1",
     "NETStandard.Library": "1.6.0",
+    "Newtonsoft.Json": "9.0.1",
     "System.Linq": "4.1.0",
     "System.Runtime.Serialization.Xml": "4.1.1"
   },
@@ -17,7 +17,7 @@
   "frameworks": {
     "netstandard1.6": {
       "imports": [
-        "dnxcore50",
+        "netcoreapp1.0",
         "netcore45",
         "portable-net45+netcore45+wp8+wp81+wpa81"
       ]
@@ -27,8 +27,10 @@
     "exclude": [
       "**.xproj",
       "**.user",
-      "**.vspscc"
+      "**.vspscc",
+      "bin",
+      "obj"
     ]
   },
-  "version": "1.0.0"
+  "version": "1.0.1"
 }


### PR DESCRIPTION
-Update app for ASP.NET Core 1.0.1.
-Update tools to version 1.0.0-preview2-003131
-Remove references to deprecated `dnxcore50` moniker and replace with `netcoreapp1.0`
-Remove reference to `Microsoft.AspNetCore.Mvc` and replace with `Microsoft.Extensions.DependencyInjection` in WatsonServices project because this is the package that was actually needed from all of the dependencies that `Microsoft.AspNetCore.Mvc` pulls in.